### PR TITLE
uses relative link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is my Dockerfiles.
 
 ## Server
 
-- [h2o](https://github.com/tcnksm/dockerfiles/tree/master/h2o)
-- [nghttp2](https://github.com/tcnksm/dockerfiles/tree/master/nghttp2)
+- [h2o](/h2o)
+- [nghttp2](/nghttp2)
 
 
 ## Author


### PR DESCRIPTION
see http://dqn.sakusakutto.jp/2014/06/github_md_link.html

絶対URLだと所有者やブランチ名が固定化されてしまい、forkしたりブランチを切ったときにリンク関係が壊れてしまうので、直してみました。
